### PR TITLE
Privatized mudules to improve the documentation layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+//! score is a general purpose discrete event simulator written in rust.
+//! The key types are:
+//!
+//! *   Simulation is responsible for coordinating the execution of the simulation.
+//! *   Components are used to define the structure of the simulation. Active components have a thread used to handle events.
+//! *   Events are named messages sheduled to be delivered to a component at a specific time. Events may have am optional payload (which must satisfy the Any and Send traits).
+//! *   The Store is where components persist state. (Using the store allows state to be viewed and changed using GUI tools like sdebug and allows side effects to be carefully managed.)
+//! *   Components use an Effector to make changes. Components can use a an effector to log, change their own state within the store, and schedule events to be sent to arbitrary components.
+
 extern crate glob;
 extern crate rand;
 extern crate rustc_serialize;
@@ -21,19 +31,19 @@ extern crate time;
 #[macro_use]
 extern crate rouille;
 
-pub mod component;
-pub mod components;
-pub mod config;
-pub mod effector;
-pub mod event;
-pub mod logging;
-pub mod ports;
-pub mod simulation;
-pub mod sim_state;
-pub mod sim_time;
-pub mod store;
-pub mod thread_data;
-pub mod values;
+mod component;
+mod components;
+mod config;
+mod effector;
+mod event;
+mod logging;
+mod ports;
+mod simulation;
+mod sim_state;
+mod sim_time;
+mod store;
+mod thread_data;
+mod values;
 
 pub use component::*;
 pub use components::*;


### PR DESCRIPTION
With this pull request the documentation obtained with cargo doc (and showed by doc.rs) directly shows all the structs etc. instead of being a sequence of public reexport very difficult to browse. In my opinion this is still not the best structure for the crate.